### PR TITLE
use ADOBE_BOT_GITHUB_TOKEN as PAT for semantic-release

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
           fetch-depth: 0
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
@@ -33,5 +33,5 @@ jobs:
       - run: npm test
       - run: npm run semantic-release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}


### PR DESCRIPTION
Trying to fix https://github.com/adobe/content-lake-shared/actions/runs/5188392780/jobs/9353014328
